### PR TITLE
Add Cors policy to allow front end connection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 5.0'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 # Use Graphql gem
 gem 'graphql'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4)
@@ -176,6 +178,7 @@ DEPENDENCIES
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 6.1.4)
   rspec-rails (~> 5.0, >= 5.0.1)
   spring

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'localhost:5000'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
Now our Svelte app can GET & POST data via Graphql.

For now we only allow connection from 'localhost:5000'. In the future we want to also allow connection from the production server. 

An even better thing to do is to automaticaly select the url based on the state of the app, e.g. PRODUCTION, TEST or DEV.